### PR TITLE
Add AdGuard DNS and Custom DNS w/ error checking

### DIFF
--- a/wrn-fix-it.py
+++ b/wrn-fix-it.py
@@ -156,6 +156,8 @@ def t001():
     print(f"# Back ....................... [10] (enter)")
     print(f"#")
 
+    # TODO: This whole input wall could be refactored.
+
     while True:
         user_input = input("t001_option=# > ")
 
@@ -215,7 +217,49 @@ def t001():
             break
         elif user_input == "8":
             # AdGuard DNS
-            pass
+            clear()
+            print(f"# {divider}")
+            print(f"# {appname} v{appvers} - {appstat}")
+            print(f"# by {dev}")
+            print(f"# {divider}")
+            print(f"#")
+            print(f"# Select your AdGuard DNS of choice.")
+            print(f"#")
+            print(f"# AdGuard (Default) .......... [1]")
+            print(f"# AdGuard (Family) ........... [2]")
+            print(f"# AdGuard (Non-Filtering) .... [3]")
+            print(f"# Back ....................... [4] Enter")
+            print(f"#")
+
+            while True:
+                user_input = input("adGuardMenu=# > ")
+
+                t001_d0 = "0"
+                if user_input == "1":
+                    # AdGuard (Default)
+                    t001_d1 = "94.140.14.14"
+                    t001_d2 = "94.140.15.15"
+                    t001_1(t001_d0, t001_d1, t001_d2)
+                    break
+                elif user_input == "2":
+                    # AdGuard (Family)
+                    t001_d1 = "94.140.14.15"
+                    t001_d2 = "94.140.15.16"
+                    t001_1(t001_d0, t001_d1, t001_d2)
+                    break
+                elif user_input == "3":
+                    # AdGuard (Non-Filtering)
+                    t001_d1 = "94.140.14.140"
+                    t001_d2 = "94.140.14.141"
+                    t001_1(t001_d0, t001_d1, t001_d2)
+                    break
+                elif user_input == "4" or user_input == "":
+                    t001()
+                else:
+                    print("Invalid input. Please try again.")
+                    continue
+            break
+
         elif user_input == "9":
             # Custom DNS
             pass

--- a/wrn-fix-it.py
+++ b/wrn-fix-it.py
@@ -1,6 +1,7 @@
 from os import system, name
 import sys
 import ctypes
+import re
 
 appname = "WRN Fix IT"
 appvers = "1.0.0-rc.2"
@@ -134,6 +135,28 @@ def t001_1(t001_d0 = "1", t001_d1 = None, t001_d2 = None):
         t001_1_linux(t001_d0, t001_d1, t001_d2)
 
 
+def check_dns_format(address):
+    """Check the validity of an inputted DNS address.
+       Warn the user and ask to continue if the DNS address
+       is not in a recognizable format."""
+  
+    # Regex to check the format of DNS address for safety
+    dns_regex = re.compile(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$')
+    if not dns_regex.match(address):
+        print(f"# WARNING:")
+        print(f"# The DNS address above does not match the") 
+        print(f"# standard DNS address format.")
+        print(f"#")
+        print(f"# Continue? (Y/N)")
+        user_input = input("dnsNotRecognized=# > ")
+        if user_input.lower() == "y":
+            return True
+        else:
+            return False
+
+    return True
+
+
 def t001():
     """Make the user select the DNS server to change into."""
 
@@ -262,7 +285,65 @@ def t001():
 
         elif user_input == "9":
             # Custom DNS
-            pass
+            clear()
+            print(f"# {divider}")
+            print(f"# {appname} v{appvers} - {appstat}")
+            print(f"# by {dev}")
+            print(f"# {divider}")
+            print(f"#")
+
+            t001_d0 = "0"
+            t001_d1 = ""
+            t001_d2 = ""
+
+            # Primary DNS address
+            while True:
+                print(f"# Type the primary DNS address:")
+                print(f"# (Type q or enter without input to exit)")
+                user_input = input("customDNS1=# > ")
+
+                if user_input.lower() == "q" or user_input == "":
+                    t001()
+                    break
+
+                # If the user types an unrecognizable DNS address,
+                # confirm if that's what they really want
+                exit_custom_dns = not check_dns_format(user_input)
+
+                # If successfully gotten a primary DNS address,
+                # assign it to t001_d1
+                if not exit_custom_dns:
+                    t001_d1 = user_input
+                    break
+
+            # If the primary DNS address remains blank,
+            # that means the program should go back to the
+            # tool selection
+            if t001_d1 == "":
+                t001()
+                break
+
+            # Secondary DNS address
+            while True:
+                print(f"# Type the secondary DNS address:")
+                print(f"# (Type q or enter without input to exit)")
+                user_input = input("customDNS2=# > ")
+
+                if user_input.lower() == "q" or user_input == "":
+                    t001()
+                    break
+
+                # If the user types an unrecognizable DNS address,
+                # confirm if that's what they really want
+                exit_custom_dns = not check_dns_format(user_input)
+
+                # If successfully gotten a secondary DNS address,
+                # assign it to t001_d2 and start the DNS reassignment
+                if not exit_custom_dns:
+                    t001_d2 = user_input
+                    t001_1(t001_d0, t001_d1, t001_d2)
+                    break
+            break
         elif user_input == "10" or user_input == "":
             # Go back to tools menu
             tools_menu()

--- a/wrn-fix-it.py
+++ b/wrn-fix-it.py
@@ -151,7 +151,9 @@ def t001():
     print(f"# Quad9 DNS .................. [5]")
     print(f"# Verisign DNS ............... [6]")
     print(f"# OpenDNS .................... [7]")
-    print(f"# Back ....................... [8] (enter)")
+    print(f"# AdGuard (more).............. [8]")
+    print(f"# Custom ..................... [9]")
+    print(f"# Back ....................... [10] (enter)")
     print(f"#")
 
     while True:
@@ -211,7 +213,14 @@ def t001():
             t001_d2 = "208.67.220.220"
             t001_1(t001_d0, t001_d1, t001_d2)
             break
-        elif user_input == "8" or user_input == "":
+        elif user_input == "8":
+            # AdGuard DNS
+            pass
+        elif user_input == "9":
+            # Custom DNS
+            pass
+        elif user_input == "10" or user_input == "":
+            # Go back to tools menu
             tools_menu()
             break
         else:


### PR DESCRIPTION
## AdGuard DNS and Custom DNS
#4 #14

What this pull request does:
- Add three AdGuard DNS addresses in the DNS changer tool (Default, Family, and Non-Filtering)
- Add an entry for manually setting custom DNS addresses

### Custom DNS error checking
Typos typed in the custom DNS field could cause issues.  The program will check the validity of a DNS address with a regex function to help mitigate this.

If the DNS address is not recognizable (e.g. `192.q18.1.w` or `2,2,2,2` instead of `192.168.1.1`), the program will prompt the user with a yes or no prompt (default no) to confirm if they really want the said address.