### PR TITLE
add Reg Ex and  Required DNS Server

### DIFF
--- a/wrn-fix-it.sh
+++ b/wrn-fix-it.sh
@@ -266,22 +266,38 @@ ${header}
 "
     clear
     read -p "# $ WRN Fix IT(1st DNS)>" custom_dns1
-    printf "${GREEN}
+    if [[ $custom_dns1 =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        printf "${GREEN}
 ${header}
 #
 # DNS Server 1: $custom_dns1
 # DNS Server 2:
 #
-"
+"   
+    else
+        clear
+        printf "${RED}[!] ERROR Cannot Add DNS, Please Check your DNS Server\n"
+        printf "${CYAN}[!] DNS Input: ${custom_dns1}"
+        sleep 5
+        menu
+    fi
     clear
     read -p "# $ WRN Fix IT(2nd DNS)>" custom_dns2
-    printf "${GREEN}
+    if [[ $custom_dns2 =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        printf "${GREEN}
 ${header}
 #
 # DNS Server 1: $custom_dns1
 # DNS Server 2: $custom_dns2
 #
 "
+    else
+        clear
+        printf "${RED}[!] ERROR Cannot Add DNS, Please Check your DNS Server\n"
+        printf "${CYAN}[!] DNS Input:  ${custom_dns2}"
+        sleep 5
+        menu
+    fi
     set_custom_dns
 }
 

--- a/wrn-fix-it.sh
+++ b/wrn-fix-it.sh
@@ -197,11 +197,7 @@ set_custom_dns() {
         mv /etc/resolv.conf /etc/resolv.conf.bak
     fi
     echo "nameserver $custom_dns1" > /etc/resolv.conf
-    if [[ -z "$custom_dns2" ]]; then
-        :
-    else
-        echo "nameserver $custom_dns2" >> /etc/resolv.conf
-    fi
+    echo "nameserver $custom_dns2" >> /etc/resolv.conf
     clear
     printf "${GREEN}
 ${header}
@@ -261,7 +257,7 @@ custom_dns_input() {
 ${header}
 #
 # Custom DNS
-# If don't have a second DNS Server just press (enter)
+# Custom DNS, Requires 2 DNS Servers
 #
 "
     clear


### PR DESCRIPTION
add Required DNS Servers, so the DNS Server will have a 2nd DNS To connect to if the first DNS failed

REG Ex
Typos typed in the custom DNS field could cause issues. The program will check the validity of a DNS address with a regex function to help mitigate this.

If the DNS address is not recognizable (e.g. 192.q18.1.w or 2,2,2,2 instead of 192.168.1.1), the program will prompt the user with a yes or no prompt (default no) to confirm if they really want the said address.